### PR TITLE
Fix crash caused by accessing null file pointer

### DIFF
--- a/wsd.c
+++ b/wsd.c
@@ -57,9 +57,9 @@
 
 #include <stdbool.h> // bool
 #include <stdio.h> // FILE, fopen(), fscanf(), snprintf(), asprintf()
-#include <stdlib.h> // srand48()
+#include <stdlib.h> // srand48(), strtoul()
 #include <unistd.h> // usleep()
-#include <string.h> // strcmp(), strdup()
+#include <string.h> // strcmp(), strdup(), strncpy()
 #include <ctype.h> // isdigit(), isspace()
 #include <time.h> // time_t, time()
 #include <errno.h> // errno
@@ -71,23 +71,37 @@
 static time_t wsd_instance;
 static char wsd_sequence[UUIDLEN], wsd_endpoint[UUIDLEN];
 
+static void uuid_endpoint(char uuid[UUIDLEN]);
+
+static int uuid_parse(char uuid[UUIDLEN], unsigned short UUID[8])
+{
+	size_t pos[] = {0,4,9,14,19,24,28,32};
+	for(size_t i = 0; i < 8; ++i) {
+		char str[5];
+		strncpy(str, uuid+pos[i], 4);
+		str[4] = '\0';
+		unsigned long s = strtoul(str, NULL, 16);
+		UUID[i] = s;
+	}
+	return 0;
+}
+
 static void set_seed(void)
 {
-	FILE *fp = fopen("/etc/machine-id", "r");
+	char uuid[UUIDLEN];
+	unsigned short UUID[8];
 	unsigned long seed;
 
+	uuid_endpoint(uuid);
+	uuid_parse(uuid, UUID);
+
 	time((time_t *)&seed);
-
-	fseek(fp, 0, SEEK_END);
-
-	if (fp && 0 != ftell(fp) ) {
-		unsigned long s;
-		rewind(fp);
-
-		while (fscanf(fp, "%8lx", &s) > 0)
-			seed ^= s;
-		fclose(fp);
+	
+	for(size_t i = 0; i < 4; ++i) {
+		unsigned long s = UUID[2*i+1] | UUID[2*i+0] << 16;
+		seed ^= s;
 	}
+
 	srand48(seed);
 }
 


### PR DESCRIPTION
The function set_seed did not check if the file /etc/machine-id exists
resulting in a crash. Using uuid_endpoint instead allows falling back to
alternatives and prevent crashes.